### PR TITLE
Implement NonZero operator

### DIFF
--- a/core/src/main/scala/com/stripe/agate/eval/Model.scala
+++ b/core/src/main/scala/com/stripe/agate/eval/Model.scala
@@ -371,6 +371,9 @@ object Model {
           case None =>
             Failure(new Exception("ATen requires an operator (none found)"))
         }
+      },
+      OpBuilder("NonZero") { (x: OpData) =>
+        Try(Operation.NonZeroOp(x.inputs(0), x.outputs(0)))
       }
     )
 

--- a/core/src/main/scala/com/stripe/agate/eval/Operation.scala
+++ b/core/src/main/scala/com/stripe/agate/eval/Operation.scala
@@ -507,11 +507,19 @@ object Operation {
       } yield regs1
   }
 
+  /**
+   * This is the NonZero operator which computes the indices of the non-zero elements in the input
+   * tensor.
+   *
+   * Important note: Since the ONNX spec and PyTorch differ here, we are returning the transposed result
+   * in order to match what PyTorch computes.
+   *
+   */
   case class NonZeroOp(input: Register, output: Register) extends Operation {
     def apply(regs0: Registers): Try[Registers] =
       for {
         t0 <- regs0.get(input)
-        result = t0.nonZero
+        result = t0.nonZero.transposeDefault
         regs1 <- regs0.create(output, result)
       } yield regs1
   }

--- a/core/src/main/scala/com/stripe/agate/eval/Operation.scala
+++ b/core/src/main/scala/com/stripe/agate/eval/Operation.scala
@@ -506,4 +506,13 @@ object Operation {
         regs1 <- regs.create(output, res)
       } yield regs1
   }
+
+  case class NonZeroOp(input: Register, output: Register) extends Operation {
+    def apply(regs0: Registers): Try[Registers] =
+      for {
+        t0 <- regs0.get(input)
+        result = t0.nonZero
+        regs1 <- regs0.create(output, result)
+      } yield regs1
+  }
 }

--- a/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
@@ -155,10 +155,18 @@ abstract class Tensor[D <: DataType] {
     }
   }
 
+  /**
+   * This function computes the set of indices of a tensor for which it is non-zero.
+   * It returns a tensor of shape (rank, #nonzero),  where #nonzero is the number of
+   * non-zero elements in the tensor, and rank is the rank of the original tensor.
+   * In other words each column in the output is the index for which the original
+   * tensor has a non-zero value.
+   * See https://github.com/onnx/onnx/blob/master/docs/Operators.md#NonZero for ONNX reference
+   *
+   * Interestingly, the pytorch implementation (https://github.com/onnx/onnx/blob/master/docs/Operators.md#NonZero)
+   * returns the transpose this.
+   */
   def nonZero: Tensor[DataType.Int64.type] = {
-    // Note that this will return a tensor of shape (rank, #nonzero)
-    // where #nonzero is the number of non-zero elements in the tensor.
-
     val num = OnnxNumber.forDataType(dataType)
 
     var filtered = new ListBuffer[Shape[Coord]]()

--- a/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
@@ -15,6 +15,8 @@ import java.util.Arrays
 import org.typelevel.paiges.Doc
 import scala.util.{Failure, Success, Try}
 
+import scala.collection.mutable.ListBuffer
+
 import Shape._
 
 abstract class Tensor[D <: DataType] {
@@ -159,13 +161,13 @@ abstract class Tensor[D <: DataType] {
 
     val num = OnnxNumber.forDataType(dataType)
 
-    val filtered = axes.coords.foldLeft(List[Shape[Coord]]()) { (list, coord) =>
+    var filtered = new ListBuffer[Shape[Coord]]()
+
+    axes.coords.foreach { coord =>
       {
         val x = this(coord)
         if (!num.zero.equals(x)) {
-          list ++ List[Shape[Coord]](coord)
-        } else {
-          list
+          filtered += coord
         }
       }
     }

--- a/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
@@ -256,12 +256,8 @@ object OperationTest extends Properties("OperationTest") {
   property("NonZero works") = {
     // Check that the NonZero operator works. Note that more detailed tests are in the TensorTest file
 
-    val c1 = {
-      val t0 = tensor"[[3, 4, 0, 6], [0, 0, 0, 7]]"
-      val expected = tensor"[[0, 0, 0, 1], [0, 1, 3, 3]]".map(DataType.Int64)(_.toLong)
-      test("NonZero", t0 :: Nil, List(expected), Map.empty)
-    }
-
-    c1
+    val t0 = tensor"[[3, 4, 0, 6], [0, 0, 0, 7]]"
+    val expected = tensor"[[0, 0, 0, 1], [0, 1, 3, 3]]".cast(DataType.Int64)
+    test("NonZero", t0 :: Nil, List(expected), Map.empty)
   }
 }

--- a/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
@@ -252,4 +252,16 @@ object OperationTest extends Properties("OperationTest") {
 
     c0 && c1 && c2 && ex1 && ex2
   }
+
+  property("NonZero works") = {
+    // Check that the NonZero operator works. Note that more detailed tests are in the TensorTest file
+
+    val c1 = {
+      val t0 = tensor"[[3, 4, 0, 6], [0, 0, 0, 7]]"
+      val expected = tensor"[[0, 0, 0, 1], [0, 1, 3, 3]]".map(DataType.Int64)(_.toLong)
+      test("NonZero", t0 :: Nil, List(expected), Map.empty)
+    }
+
+    c1
+  }
 }

--- a/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
@@ -255,9 +255,9 @@ object OperationTest extends Properties("OperationTest") {
 
   property("NonZero works") = {
     // Check that the NonZero operator works. Note that more detailed tests are in the TensorTest file
-
+    // NOTE: Here we expect the result to be the transposed version!
     val t0 = tensor"[[3, 4, 0, 6], [0, 0, 0, 7]]"
-    val expected = tensor"[[0, 0, 0, 1], [0, 1, 3, 3]]".cast(DataType.Int64)
+    val expected = tensor"[[0, 0], [0, 1], [0, 3], [1, 3]]".cast(DataType.Int64)
     test("NonZero", t0 :: Nil, List(expected), Map.empty)
   }
 }

--- a/tests/src/test/scala/com/stripe/agate/tensor/TensorTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/tensor/TensorTest.scala
@@ -824,4 +824,84 @@ object TensorTest extends Properties("TensorTest") {
 
     c1 && c2 && c3
   }
+
+  property("NonZero matches expected behavior") = {
+    val c0 = {
+      val t0 = tensor"[]"
+      val got = t0.nonZero
+      val expected = Tensor.const(DataType.Int64)(0, Shape.axes(1, 0))
+      Claim(got == expected)
+    }
+
+    val c1_1 = {
+      val t0 = tensor"[5, -1, 0, 4.4, 0, 666]"
+      val got = t0.nonZero
+      val expected = (tensor"[[0, 1, 3, 5]]").map(DataType.Int64)(_.toLong)
+      Claim(got == expected)
+    }
+
+    val c1_2 = {
+      val t0 = tensor"[0, 0, 0, 0]"
+      val got = t0.nonZero
+      val expected = Tensor.const(DataType.Int64)(0, Shape.axes(1, 0))
+      Claim(got == expected)
+    }
+
+    val c1_3 = {
+      val t0 = tensor"[0.1]"
+      val got = t0.nonZero
+      val expected = (tensor"[[0]]").map(DataType.Int64)(_.toLong)
+      Claim(got == expected)
+    }
+
+    val c1_4 = {
+      val t0 = tensor"[0.1, -5, 9, 12312]"
+      val got = t0.nonZero
+      val expected = (tensor"[[0, 1, 2, 3]]").map(DataType.Int64)(_.toLong)
+      Claim(got == expected)
+    }
+
+    val c2_1 = {
+      val t0 = tensor"[[0, 0, 0], [0, 0, 0]]"
+      val got = t0.nonZero
+      val expected = Tensor.const(DataType.Int64)(0, Shape.axes(2, 0))
+      Claim(got == expected)
+    }
+
+    val c2_2 = {
+      val t0 = tensor"[[0, 1, 0], [1, 0, 1]]"
+      val got = t0.nonZero
+      val expected = (tensor"[[0, 1, 1], [1, 0, 2]]").map(DataType.Int64)(_.toLong)
+      Claim(got == expected)
+    }
+
+    val c2_3 = {
+      val t0 = tensor"[[9, 1, 0], [1, 0, 1]]"
+      val got = t0.nonZero
+      val expected = (tensor"[[0, 0, 1, 1], [0, 1, 0, 2]]").map(DataType.Int64)(_.toLong)
+      Claim(got == expected)
+    }
+
+    val c2_4 = {
+      val t0 =
+        tensor"[[0.6, 0.0, 0.0, 0.0], [0.0, 0.4, 0.0, 0.0], [0.0, 0.0, 1.2, 0.0], [0.0, 0.0, 0.0,-0.4]]"
+      val got = t0.nonZero
+      val expected = (tensor"[[0, 1, 2, 3], [0, 1, 2, 3]]").map(DataType.Int64)(_.toLong)
+      Claim(got == expected)
+    }
+
+    val c3 = {
+      val t0 = tensor"[[[0, 1, 2], [1, 0, 1]], [[9, 0, 0], [0, 0, 1]]]"
+      val got = t0.nonZero
+      val expected = (tensor"[[0, 0, 0, 0, 1, 1], [0, 0, 1, 1, 0, 1], [1, 2, 0, 2, 0, 2]]").map(
+        DataType.Int64
+      )(_.toLong)
+      Claim(got == expected)
+    }
+
+    c0 &&
+    c1_1 && c1_2 && c1_3 && c1_4 &&
+    c2_1 && c2_2 && c2_3 && c2_4 &&
+    c3
+  }
 }

--- a/tests/src/test/scala/com/stripe/agate/tensor/TensorTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/tensor/TensorTest.scala
@@ -836,7 +836,7 @@ object TensorTest extends Properties("TensorTest") {
     val c1_1 = {
       val t0 = tensor"[5, -1, 0, 4.4, 0, 666]"
       val got = t0.nonZero
-      val expected = (tensor"[[0, 1, 3, 5]]").map(DataType.Int64)(_.toLong)
+      val expected = (tensor"[[0, 1, 3, 5]]").cast(DataType.Int64)
       Claim(got == expected)
     }
 
@@ -850,14 +850,14 @@ object TensorTest extends Properties("TensorTest") {
     val c1_3 = {
       val t0 = tensor"[0.1]"
       val got = t0.nonZero
-      val expected = (tensor"[[0]]").map(DataType.Int64)(_.toLong)
+      val expected = (tensor"[[0]]").cast(DataType.Int64)
       Claim(got == expected)
     }
 
     val c1_4 = {
       val t0 = tensor"[0.1, -5, 9, 12312]"
       val got = t0.nonZero
-      val expected = (tensor"[[0, 1, 2, 3]]").map(DataType.Int64)(_.toLong)
+      val expected = (tensor"[[0, 1, 2, 3]]").cast(DataType.Int64)
       Claim(got == expected)
     }
 
@@ -871,14 +871,14 @@ object TensorTest extends Properties("TensorTest") {
     val c2_2 = {
       val t0 = tensor"[[0, 1, 0], [1, 0, 1]]"
       val got = t0.nonZero
-      val expected = (tensor"[[0, 1, 1], [1, 0, 2]]").map(DataType.Int64)(_.toLong)
+      val expected = (tensor"[[0, 1, 1], [1, 0, 2]]").cast(DataType.Int64)
       Claim(got == expected)
     }
 
     val c2_3 = {
       val t0 = tensor"[[9, 1, 0], [1, 0, 1]]"
       val got = t0.nonZero
-      val expected = (tensor"[[0, 0, 1, 1], [0, 1, 0, 2]]").map(DataType.Int64)(_.toLong)
+      val expected = (tensor"[[0, 0, 1, 1], [0, 1, 0, 2]]").cast(DataType.Int64)
       Claim(got == expected)
     }
 
@@ -886,7 +886,7 @@ object TensorTest extends Properties("TensorTest") {
       val t0 =
         tensor"[[0.6, 0.0, 0.0, 0.0], [0.0, 0.4, 0.0, 0.0], [0.0, 0.0, 1.2, 0.0], [0.0, 0.0, 0.0,-0.4]]"
       val got = t0.nonZero
-      val expected = (tensor"[[0, 1, 2, 3], [0, 1, 2, 3]]").map(DataType.Int64)(_.toLong)
+      val expected = (tensor"[[0, 1, 2, 3], [0, 1, 2, 3]]").cast(DataType.Int64)
       Claim(got == expected)
     }
 


### PR DESCRIPTION
This pull request implements the NonZero operator for agate. See https://github.com/onnx/onnx/blob/master/docs/Operators.md#nonzero for the ONNX reference.

Note: We may need to transpose the result of this since pytorch computes the transposed version of this. However, as-is the current implementation matches the ONNX specification.

r? @thomas-stripe @oscar-stripe 