### PR TITLE
Code is building under 2.13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,17 @@ jdk: openjdk11
 
 matrix:
   include:
-    - scala: 2.11.12
+    - scala: 2.13.1
       env: PLATFORM="jvm"
-      script: sbt "++2.11.12" coverage core/test bench/compile docs/mdoc coverageReport && codecov
+      script: sbt "++2.13.1" coverage core/test bench/compile docs/mdoc coverageReport && codecov
 
     - scala: 2.12.9
       env: PLATFORM="jvm"
       script: sbt "++2.12.9" coverage core/test bench/compile docs/mdoc coverageReport && codecov
+
+    - scala: 2.11.12
+      env: PLATFORM="jvm"
+      script: sbt "++2.11.12" coverage core/test bench/compile docs/mdoc coverageReport && codecov
 
 install:
  - pip install --user codecov

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val agateSettings = Seq(
 
   organization := "com.stripe",
   scalaVersion := "2.13.1",
-  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.1"),
+  crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1"),
 
   Global / onChangedBuildSource := ReloadOnSourceChanges,
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,21 +2,21 @@ lazy val readmeVersion = "0.0.10"
 
 lazy val scalacheckVersion = "1.14.2"
 
-lazy val fastparseVersion = "1.0.0"
+lazy val fastparseVersion = "1.0.1"
 
 lazy val agateSettings = Seq(
 
   organization := "com.stripe",
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.11.12", "2.12.8"),
+  scalaVersion := "2.13.1",
+  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.1"),
 
   Global / onChangedBuildSource := ReloadOnSourceChanges,
 
   libraryDependencies ++=
     "org.scala-lang" % "scala-reflect" % scalaVersion.value ::
     "com.chuusai" %% "shapeless" % "2.3.3" ::
-    "com.stripe" %% "dagon-core" % "0.3.2" ::
-    "com.lihaoyi" %% "fastparse" % fastparseVersion ::
+    "com.stripe" %% "dagon-core" % "0.3.3" ::
+    "org.scalameta" %% "fastparse" % fastparseVersion ::
     "com.monovore" %% "decline" % "1.0.0" ::
     "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test" ::
     "org.typelevel" %% "claimant" % "0.1.2" % "test" ::
@@ -25,11 +25,25 @@ lazy val agateSettings = Seq(
     "org.typelevel" %% "paiges-core" % "0.3.0" ::
     Nil,
 
-  dependencyOverrides ++=
-    "com.lihaoyi" %% "fastparse" % fastparseVersion ::
-    Nil,
-
+  // shared scalac options
   scalacOptions ++= options,
+
+  // per-version scalac options
+  scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, x)) if x <= 12 =>
+      "-Xfuture" ::                          // Turn on future language features.
+      "-Xlint:by-name-right-associative" ::  // By-name parameter of right associative operator.
+      "-Xlint:unsound-match" ::              // Pattern match may not be typesafe.
+      "-Yno-adapted-args" ::                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+      "-Ypartial-unification" ::             // Enable partial unification in type constructor inference
+      "-Ywarn-inaccessible" ::               // Warn about inaccessible types in method signatures.
+      "-Ywarn-infer-any" ::                  // Warn when a type argument is inferred to be `Any`.
+      "-Ywarn-nullary-override" ::           // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Ywarn-nullary-unit" ::               // Warn when nullary methods return Unit.
+      Nil
+    case _ =>
+      Nil
+  }),
   scalacOptions in (Compile, console) ~= { _.filterNot("-Xlint" == _) },
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
 
@@ -119,10 +133,8 @@ lazy val options = Seq(
   "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
   "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
   "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-  "-Xfuture",                          // Turn on future language features.
   "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-  "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
-  ///"-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
+  //"-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
   "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
   "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
   "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
@@ -136,22 +148,15 @@ lazy val options = Seq(
   "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
   "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
   "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-  "-Xlint:unsound-match",              // Pattern match may not be typesafe.
-  "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-  "-Ypartial-unification",             // Enable partial unification in type constructor inference
   //"-Ywarn-dead-code",                  // Warn when dead code is identified.
-  ///"-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-  "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-  "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
-  "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-  "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+  //"-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
   //"-Ywarn-numeric-widen",              // Warn when numerics are widened.
-  ///"-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-  ///"-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
-  ///"-Ywarn-unused:locals",              // Warn if a local definition is unused.
-  ///"-Ywarn-unused:params",              // Warn if a value parameter is unused.
-  ///"-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
-  ///"-Ywarn-unused:privates",            // Warn if a private member is unused.
-  ////"-Ywarn-unused-imports",             // Warn if an import selector is not referenced.
+  //"-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+  //"-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+  //"-Ywarn-unused:locals",              // Warn if a local definition is unused.
+  //"-Ywarn-unused:params",              // Warn if a value parameter is unused.
+  //"-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+  //"-Ywarn-unused:privates",            // Warn if a private member is unused.
+  //"-Ywarn-unused-imports",             // Warn if an import selector is not referenced.
   "-Ywarn-value-discard"               // Warn when non-Unit expression results are unused.
 )

--- a/core/src/main/scala/com/stripe/agate/eval/Agate.scala
+++ b/core/src/main/scala/com/stripe/agate/eval/Agate.scala
@@ -10,8 +10,6 @@ import java.nio.file.{Files, Path}
 import onnx.onnx.{GraphProto, ModelProto, TensorProto, TensorShapeProto, TypeProto, ValueInfoProto}
 import org.typelevel.paiges.Doc
 
-import scala.collection.JavaConverters._
-
 import cats.implicits._
 
 object Agate {
@@ -72,7 +70,12 @@ object Agate {
     def showRaw(bytes: ByteString): Doc = {
       def showSize = Doc.text(s"<${bytes.size} literal bytes>")
       if (bytes.size < 30) {
-        val ascii = bytes.iterator.asScala.forall(b => 32 <= b && b < 127)
+        var ascii = true
+        val it = bytes.iterator
+        while (ascii && it.hasNext) {
+          val b = it.next
+          ascii = 32 <= b && b < 127
+        }
         if (ascii) {
           Doc.text(bytes.toStringUtf8)
         } else showSize
@@ -267,7 +270,7 @@ object Agate {
     )
 
   def main(args: Array[String]): Unit =
-    tool.parse(args) match {
+    tool.parse(args.toVector) match {
       case Left(help) =>
         println(help.toString)
         System.exit(ExitCode.Error.code)

--- a/core/src/main/scala/com/stripe/agate/tensor/Shape.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Shape.scala
@@ -110,7 +110,7 @@ sealed abstract class Shape[+A] {
     valid.map { _ =>
       val shapeArray: Array[(Long, A)] = toList.toArray
       // now just remap all of these things:
-      val items = axes.reverseMap { idxLong =>
+      val items = axes.reverseIterator.map { idxLong =>
         val idx = idxLong.toInt
         shapeArray(idx)
       }
@@ -128,7 +128,7 @@ sealed abstract class Shape[+A] {
     this match {
       case Empty => Empty
       case nonEmpty =>
-        val axes = (0 until rank).toList.reverseMap(_.toLong)
+        val axes = (0 until rank).reverseIterator.map(_.toLong).toList
         // we know this get is safe
         transpose(axes).get
     }

--- a/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
@@ -169,23 +169,24 @@ abstract class Tensor[D <: DataType] {
   def nonZero: Tensor[DataType.Int64.type] = {
     val num = OnnxNumber.forDataType(dataType)
 
-    var filtered = new ListBuffer[Shape[Coord]]()
+    val bldr = List.newBuilder[Shape[Coord]]
+    //var filtered = new ListBuffer[Shape[Coord]]()
 
     axes.coords.foreach { coord =>
       {
         val x = this(coord)
         if (!num.zero.equals(x)) {
-          filtered += coord
+          //filtered += coord
+          bldr += coord
         }
       }
     }
 
-    val listOfVectors = filtered.map { coords =>
-      {
+    val listOfVectors: Seq[Tensor[DataType.Int64.type]] =
+      bldr.result.map { coords =>
         val array = coords.toList.map(_._1).toArray
         Tensor.vector(DataType.Int64)(array)
-      }
-    }
+      }.toList
 
     if (listOfVectors.isEmpty) {
       // If there are no non-zero values, return tensor of shape (rank, 0)

--- a/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
@@ -169,25 +169,16 @@ abstract class Tensor[D <: DataType] {
   def nonZero: Tensor[DataType.Int64.type] = {
     val num = OnnxNumber.forDataType(dataType)
 
-    val bldr = List.newBuilder[Shape[Coord]]
-    //var filtered = new ListBuffer[Shape[Coord]]()
-
+    val bldr = List.newBuilder[Tensor[DataType.Int64.type]]
     axes.coords.foreach { coord =>
-      {
-        val x = this(coord)
-        if (!num.zero.equals(x)) {
-          //filtered += coord
-          bldr += coord
-        }
+      val x = this(coord)
+      if (!num.zero.equals(x)) {
+        val array = coord.toList.map(_._1).toArray
+        bldr += Tensor.vector(DataType.Int64)(array)
       }
     }
 
-    val listOfVectors: Seq[Tensor[DataType.Int64.type]] =
-      bldr.result.map { coords =>
-        val array = coords.toList.map(_._1).toArray
-        Tensor.vector(DataType.Int64)(array)
-      }.toList
-
+    val listOfVectors = bldr.result
     if (listOfVectors.isEmpty) {
       // If there are no non-zero values, return tensor of shape (rank, 0)
       Tensor.const(DataType.Int64)(0, Shape.axes(dims.rank, 0))

--- a/core/src/main/scala/com/stripe/agate/tensor/TensorParser.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/TensorParser.scala
@@ -2,7 +2,7 @@ package com.stripe.agate.tensor
 
 import cats.data.Chain
 import com.stripe.dagon.HMap
-import fastparse.all._
+import scala.meta.internal.fastparse.all._
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 import scala.util.{Failure, Success, Try}

--- a/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
@@ -32,11 +32,9 @@ object OperationTest extends Properties("OperationTest") {
     Model.supportedOps.get(opName) match {
       case None => Prop(false) :| s"operator $opName not supported"
       case Some(bldr) =>
-        val nums = Stream.iterate(0)(_ + 1).map { i =>
-          Register(i.toString)
-        }
-        val ins = nums.zip(inputs.toStream)
-        val outs = nums.drop(ins.size).zip(outputs.toStream)
+        val ins = inputs.zipWithIndex.map { case (n, i) => (Register(i.toString), n) }
+        val off = ins.size
+        val outs = outputs.zipWithIndex.map { case (o, i) => (Register((i + off).toString), o) }
         val opData = OpData(s"test of $opName", ins.map(_._1), outs.map(_._1), attrs)
         val registers = Registers(ins.toMap)
         bldr.build(opData).flatMap(_(registers)) match {

--- a/tests/src/test/scala/com/stripe/agate/tensor/BFloat16Test.scala
+++ b/tests/src/test/scala/com/stripe/agate/tensor/BFloat16Test.scala
@@ -1,7 +1,7 @@
 package com.stripe.agate
 package tensor
 
-import java.lang.{Double => JDouble, Float => JFloat, Integer => JInteger}
+import java.lang.{Double => JDouble, Float => JFloat, Integer => JInteger, Math}
 import org.typelevel.claimant.Claim
 import org.scalacheck.{Gen, Prop, Properties}
 import org.scalacheck.Prop.{forAllNoShrink => forAll}
@@ -127,14 +127,14 @@ object BFloat16Test extends Properties("BFloat16Test") {
     forAll(genAny, genAny) { (x, y) =>
       val lhs = (x compare y)
       val rhs = JFloat.compare(x.toFloat, y.toFloat)
-      Prop(lhs.signum == rhs.signum) :| s"$lhs ~ $rhs"
+      Prop(Math.signum(lhs) == Math.signum(rhs)) :| s"$lhs ~ $rhs"
     }
 
   property("(x compare y) is consistent (x < y)") = forAll(genNonNaN, genNonNaN) { (x, y) =>
     if (x < y) {
-      Claim(x.compare(y).signum == -1)
+      Claim(Math.signum(x.compare(y)) == -1)
     } else {
-      Claim(x.compare(y).signum != -1)
+      Claim(Math.signum(x.compare(y)) != -1)
     }
   }
 

--- a/tests/src/test/scala/com/stripe/agate/tensor/Float16Test.scala
+++ b/tests/src/test/scala/com/stripe/agate/tensor/Float16Test.scala
@@ -1,7 +1,7 @@
 package com.stripe.agate
 package tensor
 
-import java.lang.{Double => JDouble, Float => JFloat, Integer => JInteger}
+import java.lang.{Double => JDouble, Float => JFloat, Integer => JInteger, Math}
 import org.typelevel.claimant.Claim
 import org.scalacheck.{Gen, Prop, Properties}
 import org.scalacheck.Prop.{forAllNoShrink => forAll}
@@ -127,14 +127,14 @@ object Float16Test extends Properties("Float16Test") {
     forAll(genAny, genAny) { (x, y) =>
       val lhs = (x compare y)
       val rhs = JFloat.compare(x.toFloat, y.toFloat)
-      Prop(lhs.signum == rhs.signum) :| s"$lhs ~ $rhs"
+      Prop(Math.signum(lhs) == Math.signum(rhs)) :| s"$lhs ~ $rhs"
     }
 
   property("(x compare y) is consistent (x < y)") = forAll(genNonNaN, genNonNaN) { (x, y) =>
     if (x < y) {
-      Claim(x.compare(y).signum == -1)
+      Claim(Math.signum(x.compare(y)) == -1)
     } else {
-      Claim(x.compare(y).signum != -1)
+      Claim(Math.signum(x.compare(y)) != -1)
     }
   }
 

--- a/tests/src/test/scala/com/stripe/agate/tensor/TensorParserTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/tensor/TensorParserTest.scala
@@ -7,7 +7,7 @@ import org.typelevel.claimant.Claim
 import scala.util.{Failure, Success}
 
 import cats.implicits._
-import fastparse.all._
+import scala.meta.internal.fastparse.all._
 import com.stripe.agate.laws.Check._
 import TestImplicits._
 


### PR DESCRIPTION
The tests have not been converted yet. We have the usual mix of deprecated
stuff whose replacements weren't available in 2.12. Good times!

One weird thing we did was use ScalaMeta's fork of fastparse, to get the 1.x
API published for 2.13.