### PR TITLE
Add DataType.String (DT_STRING) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ matrix:
   include:
     - scala: 2.13.1
       env: PLATFORM="jvm"
-      script: sbt "++2.13.1" scalafmtCheckAll coverage core/test bench/compile docs/mdoc coverageReport && codecov
+      script: sbt "++2.13.1" scalafmtCheckAll coverage core/test tests/test bench/compile docs/mdoc coverageReport && codecov
 
     - scala: 2.12.9
       env: PLATFORM="jvm"
-      script: sbt "++2.12.9" scalafmtCheckAll coverage core/test bench/compile docs/mdoc coverageReport && codecov
+      script: sbt "++2.12.9" scalafmtCheckAll coverage core/test tests/test bench/compile docs/mdoc coverageReport && codecov
 
     - scala: 2.11.12
       env: PLATFORM="jvm"
-      script: sbt "++2.11.12" scalafmtCheckAll coverage core/test bench/compile docs/mdoc coverageReport && codecov
+      script: sbt "++2.11.12" scalafmtCheckAll coverage core/test tests/test bench/compile docs/mdoc coverageReport && codecov
 
 install:
  - pip install --user codecov

--- a/bench/src/main/scala/com/stripe/agate/bench/MatrixMultBench.scala
+++ b/bench/src/main/scala/com/stripe/agate/bench/MatrixMultBench.scala
@@ -102,7 +102,7 @@ class MatrixMultBench {
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   def rowMajorTimesRowMajor(): Array[Float] = {
     val dt = DataType.Float32
-    val on = OnnxNumber.forDataType(dt)
+    val on = OnnxNumber.forDataTypeOrThrow(dt)
     rowTimesRow[dt.Elem](left, right, on)
   }
 

--- a/core/src/main/scala/com/stripe/agate/eval/Model.scala
+++ b/core/src/main/scala/com/stripe/agate/eval/Model.scala
@@ -42,7 +42,7 @@ object Model {
       case DataType.Int16   => 5
       case DataType.Int32   => 6
       case DataType.Int64   => 7
-      // String => 8
+      case DataType.String  => 8
       // Boolean => 9
       case DataType.Float16 => 10
       case DataType.Float64 => 11
@@ -68,6 +68,7 @@ object Model {
       case 5     => Success(DataType.Int16)
       case 6     => Success(DataType.Int32)
       case 7     => Success(DataType.Int64)
+      case 8     => Success(DataType.String)
       case 10    => Success(DataType.Float16)
       case 11    => Success(DataType.Float64)
       case 16    => Success(DataType.BFloat16)
@@ -534,6 +535,7 @@ object Model {
       case d: DataType.Float16.type  => conv(d)(tp.int32Data)(x => (x & 0xffff).toShort)
       case d: DataType.Float32.type  => conv(d)(tp.floatData)(x => x)
       case d: DataType.Float64.type  => conv(d)(tp.doubleData)(x => x)
+      case d: DataType.String.type   => conv(d)(tp.stringData)(x => x)
     }
   }
 

--- a/core/src/main/scala/com/stripe/agate/eval/Operation.scala
+++ b/core/src/main/scala/com/stripe/agate/eval/Operation.scala
@@ -34,7 +34,7 @@ object Operation {
     def apply(regs0: Registers): Try[Registers] =
       for {
         t0 <- regs0.get(input)
-        num = OnnxNumber.forDataType(t0.dataType)
+        num <- OnnxNumber.forDataType(t0.dataType)
         ev <- OnnxNumber.toFloating(num)
         t1 = t0.map(op(ev))
         regs1 <- regs0.create(output, t1)
@@ -79,7 +79,8 @@ object Operation {
         left0 <- regs0.get(input0)
         left = left0.asDataTyped
         right <- regs0.getAndUnify(input1, left.dataType)
-        result <- Tensor.map2(left.dataType)(left, right)(op(OnnxNumber.forDataType(left.dataType)))
+        num <- OnnxNumber.forDataType(left.dataType)
+        result <- Tensor.map2(left.dataType)(left, right)(op(num))
         regs1 <- regs0.create(output, result)
       } yield regs1
   }

--- a/core/src/main/scala/com/stripe/agate/ops/BatchNormalization.scala
+++ b/core/src/main/scala/com/stripe/agate/ops/BatchNormalization.scala
@@ -26,10 +26,12 @@ object BatchNormalization {
       mean0: Tensor[dataType.type],
       variance0: Tensor[dataType.type],
       epsilon: Float
-  ): Try[Tensor[dataType.type]] = {
-    implicit val alloc = StorageAllocator.forDataType(dataType)
-    val num = OnnxNumber.forDataType(dataType)
-    OnnxNumber.toFloating(num).map { fl =>
+  ): Try[Tensor[dataType.type]] =
+    for {
+      num <- OnnxNumber.forDataType(dataType)
+      fl <- OnnxNumber.toFloating(num)
+    } yield {
+      implicit val alloc = StorageAllocator.forDataType(dataType)
       implicit val floatA = fl
 
       require(data0.rank > 0)
@@ -75,5 +77,4 @@ object BatchNormalization {
       val axes: Dims = outputAxes.asRowMajorDims
       Tensor(dataType, axes)(st)
     }
-  }
 }

--- a/core/src/main/scala/com/stripe/agate/ops/Gather.scala
+++ b/core/src/main/scala/com/stripe/agate/ops/Gather.scala
@@ -19,10 +19,11 @@ object Gather {
       data: Tensor[D1],
       indices: Tensor[D2],
       axis: Long
-  ): Try[Tensor[data.dataType.type]] = {
-    val num = OnnxNumber.forDataType(indices.dataType)
-
-    OnnxNumber.toIntegral(num).map { in =>
+  ): Try[Tensor[data.dataType.type]] =
+    for {
+      num <- OnnxNumber.forDataType(indices.dataType)
+      in <- OnnxNumber.toIntegral(num)
+    } yield {
       implicit val oi: OnnxIntegral[indices.dataType.Elem] = in
       implicit val alloc = StorageAllocator.forDataType(data.dataType)
 
@@ -93,5 +94,4 @@ object Gather {
         }
         .get
     }
-  }
 }

--- a/core/src/main/scala/com/stripe/agate/ops/Gemm.scala
+++ b/core/src/main/scala/com/stripe/agate/ops/Gemm.scala
@@ -156,7 +156,7 @@ object Gemm {
       transA: Boolean,
       transB: Boolean
   ): Try[Tensor[dataType.type]] = Try {
-    implicit val onnxA = OnnxNumber.forDataType(dataType)
+    implicit val onnxA = OnnxNumber.forDataTypeOrThrow(dataType)
     implicit val alloc = StorageAllocator.forDataType(dataType)
     if (a0.dims.rank != 2 || b0.dims.rank != 2) {
       sys.error(s"dimension were wrong: a=${a0.axes.axesString} b=${b0.axes.axesString}")
@@ -207,7 +207,7 @@ object Gemm {
             val xa = intoRowMajorArray[dataType.Elem](a)(ct)
             val xb = intoColMajorArray[dataType.Elem](b)(ct)
             val xc = intoRowMajorArray[dataType.Elem](c)(ct)
-            val on = OnnxNumber.forDataType(dataType)
+            val on = OnnxNumber.forDataTypeOrThrow(dataType)
             val xout = arrayGemm[dataType.Elem](
               xa,
               xb,

--- a/core/src/main/scala/com/stripe/agate/ops/Gru.scala
+++ b/core/src/main/scala/com/stripe/agate/ops/Gru.scala
@@ -78,7 +78,7 @@ object Gru {
       // println(s"input=${input.axes}")
       // println(s"weight=${weight.axes}")
 
-      val of: OnnxFloating[dt.Elem] = OnnxNumber.toFloating(OnnxNumber.forDataType(dt)).get
+      val of: OnnxFloating[dt.Elem] = OnnxNumber.toFloating(OnnxNumber.forDataTypeOrThrow(dt)).get
 
       // [ [ a b c d e f ] ]
       // splitAt(axis = 1, size = 2)

--- a/core/src/main/scala/com/stripe/agate/ops/MaxPool.scala
+++ b/core/src/main/scala/com/stripe/agate/ops/MaxPool.scala
@@ -18,8 +18,8 @@ object MaxPool {
       pads: List[Long],
       storageOrder: StorageOrder,
       strides: List[Long]
-  ): Try[Output[dt.type]] = {
-    val on: OnnxNumber[dt.Elem] = OnnxNumber.forDataType(dt)
+  ): Try[Output[dt.type]] = Try {
+    val on: OnnxNumber[dt.Elem] = OnnxNumber.forDataTypeOrThrow(dt)
 
     require(autoPad == AutoPad.NotSet)
     require(storageOrder == StorageOrder.RowMajor)
@@ -154,7 +154,7 @@ t      1 1 1 1 1
         }
     }
 
-    Try(Output(Tensor(dt, outputDims)(writable.toStorage)))
+    Output(Tensor(dt, outputDims)(writable.toStorage))
   }
 
   sealed abstract class AutoPad

--- a/core/src/main/scala/com/stripe/agate/ops/SoftMax.scala
+++ b/core/src/main/scala/com/stripe/agate/ops/SoftMax.scala
@@ -52,9 +52,11 @@ object Softmax {
     if (axis < 0) {
       Try(sys.error(s"invalid axis: $axis"))
     } else {
-      val num: OnnxNumber[input.dataType.Elem] = OnnxNumber.forDataType(input.dataType)
-      OnnxNumber.toFloating(num).flatMap { (fl: OnnxFloating[input.dataType.Elem]) =>
-        Try(run(input.dataType)(axis, fl, input.asDataTyped))
+      for {
+        num <- OnnxNumber.forDataType(input.dataType)
+        fl <- OnnxNumber.toFloating(num)
+      } yield {
+        run(input.dataType)(axis, fl, input.asDataTyped)
       }
     }
 }

--- a/core/src/main/scala/com/stripe/agate/tensor/DataType.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/DataType.scala
@@ -1,6 +1,7 @@
 package com.stripe.agate.tensor
 
 import cats.evidence.Is
+import com.google.protobuf.ByteString
 import scala.reflect.ClassTag
 
 sealed abstract class DataType(val typeName: String) {
@@ -49,6 +50,10 @@ object DataType {
   }
   case object Float64 extends DataType("float64") {
     type Elem = Double
+    val classTag = implicitly[ClassTag[Elem]]
+  }
+  case object String extends DataType("string") {
+    type Elem = ByteString
     val classTag = implicitly[ClassTag[Elem]]
   }
 

--- a/core/src/main/scala/com/stripe/agate/tensor/OnnxNumber.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/OnnxNumber.scala
@@ -534,14 +534,20 @@ object OnnxNumber {
       .updated(DataType.Float32, OnnxNumber.Float32)
       .updated(DataType.Float64, OnnxNumber.Float64)
 
-  def cast(from: DataType, to: DataType): from.Elem => to.Elem = {
-    val onF = forDataTypeOrThrow(from)
-    val onT = forDataTypeOrThrow(to)
-
-    if (onT.isInstanceOf[OnnxIntegral[_]]) { (a: from.Elem) =>
-      onT.fromLong(onF.toLong(a))
-    } else { (a: from.Elem) =>
-      onT.fromDouble(onF.toDouble(a))
+  def cast(from: DataType, to: DataType): Option[from.Elem => to.Elem] =
+    forDataTypeMap.get(from: DataType.Aux[from.Elem]) match {
+      case Some(onF) =>
+        forDataTypeMap.get(to: DataType.Aux[to.Elem]) match {
+          case Some(onT) =>
+            if (onT.isInstanceOf[OnnxIntegral[_]]) Some({ (a: from.Elem) =>
+              onT.fromLong(onF.toLong(a))
+            })
+            else
+              Some({ (a: from.Elem) =>
+                onT.fromDouble(onF.toDouble(a))
+              })
+          case None => None
+        }
+      case None => None
     }
-  }
 }

--- a/core/src/main/scala/com/stripe/agate/tensor/OnnxNumber.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/OnnxNumber.scala
@@ -525,7 +525,10 @@ object OnnxNumber {
     }
 
   def forDataType(dt: DataType): OnnxNumber[dt.Elem] =
-    forDataTypeMap(dt)
+    forDataTypeMap.get(dt: DataType.Aux[dt.Elem]) match {
+      case Some(num) => num
+      case None      => throw new IllegalArgumentException(s"not a numeric datatype=$dt")
+    }
 
   private[this] val forDataTypeMap: HMap[DataType.Aux, OnnxNumber] =
     HMap

--- a/core/src/main/scala/com/stripe/agate/tensor/OnnxNumber.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/OnnxNumber.scala
@@ -34,8 +34,6 @@ sealed trait OnnxNumber[@specialized(Byte, Short, Int, Long, Float, Double) A] {
   val dataType: Data
   def typeName: String = dataType.typeName
 
-  def render(x: A): String
-
   def zero: A
   def one: A
   def times(left: A, right: A): A
@@ -114,7 +112,6 @@ object OnnxNumber {
   val Uint8: OnnxIntegral[Byte] =
     new OnnxIntegral[Byte] {
       type Data = DataType.Uint8.type
-      def render(x: Byte): String = (x & 0xff).toString
       val dataType = DataType.Uint8
       val zero: Byte = 0.toByte
       val one: Byte = 1.toByte
@@ -144,7 +141,6 @@ object OnnxNumber {
   val Uint16: OnnxIntegral[Short] =
     new OnnxIntegral[Short] {
       type Data = DataType.Uint16.type
-      def render(x: Short): String = (x & 0xffff).toString
       val dataType = DataType.Uint16
       val zero: Short = 0.toShort
       val one: Short = 1.toShort
@@ -175,7 +171,6 @@ object OnnxNumber {
     new OnnxIntegral[Byte] {
       type Data = DataType.Int8.type
       val dataType = DataType.Int8
-      def render(x: Byte): String = x.toString
       val zero: Byte = 0.toByte
       val one: Byte = 1.toByte
       def times(left: Byte, right: Byte): Byte = (left * right).toByte
@@ -201,7 +196,6 @@ object OnnxNumber {
     new OnnxIntegral[Short] {
       type Data = DataType.Int16.type
       val dataType = DataType.Int16
-      def render(x: Short): String = x.toString
       val zero: Short = 0.toShort
       val one: Short = 1.toShort
       def times(left: Short, right: Short): Short = (left * right).toShort
@@ -227,7 +221,6 @@ object OnnxNumber {
     new OnnxIntegral[Int] {
       type Data = DataType.Int32.type
       val dataType = DataType.Int32
-      def render(x: Int): String = x.toString
       def zero: Int = 0
       def one: Int = 1
       def times(left: Int, right: Int): Int = left * right
@@ -253,7 +246,6 @@ object OnnxNumber {
     new OnnxIntegral[Long] {
       type Data = DataType.Int64.type
       val dataType = DataType.Int64
-      def render(x: Long): String = x.toString
       def zero: Long = 0L
       def one: Long = 1L
       def times(left: Long, right: Long): Long = (left * right)
@@ -279,8 +271,6 @@ object OnnxNumber {
     new OnnxFloating[Short] {
       type Data = DataType.BFloat16.type
       val dataType = DataType.BFloat16
-
-      def render(x: Short): String = lift(x).toString
 
       val zero: Short = B16.Zero.raw
       val one: Short = B16.One.raw
@@ -347,8 +337,6 @@ object OnnxNumber {
       type Data = DataType.Float16.type
       val dataType = DataType.Float16
 
-      def render(x: Short): String = lift(x).toString
-
       val zero: Short = F16.Zero.raw
       val one: Short = F16.One.raw
 
@@ -413,7 +401,6 @@ object OnnxNumber {
     new OnnxFloating[Float] {
       type Data = DataType.Float32.type
       val dataType = DataType.Float32
-      def render(x: Float): String = x.toString
       def zero: Float = 0f
       def one: Float = 1f
       def times(left: Float, right: Float): Float =
@@ -471,7 +458,6 @@ object OnnxNumber {
     new OnnxFloating[Double] {
       type Data = DataType.Float64.type
       val dataType = DataType.Float64
-      def render(x: Double): String = x.toString
       def zero: Double = 0.0
       def one: Double = 1.0
       def times(left: Double, right: Double): Double =
@@ -524,10 +510,14 @@ object OnnxNumber {
       }
     }
 
-  def forDataType(dt: DataType): OnnxNumber[dt.Elem] =
+  def forDataType(dt: DataType): Try[OnnxNumber[dt.Elem]] =
+    Try(forDataTypeOrThrow(dt))
+
+  def forDataTypeOrThrow(dt: DataType): OnnxNumber[dt.Elem] =
     forDataTypeMap.get(dt: DataType.Aux[dt.Elem]) match {
       case Some(num) => num
-      case None      => throw new IllegalArgumentException(s"not a numeric datatype=$dt")
+      case None =>
+        throw new IllegalArgumentException(s"non-numeric datatype=$dt")
     }
 
   private[this] val forDataTypeMap: HMap[DataType.Aux, OnnxNumber] =
@@ -545,8 +535,8 @@ object OnnxNumber {
       .updated(DataType.Float64, OnnxNumber.Float64)
 
   def cast(from: DataType, to: DataType): from.Elem => to.Elem = {
-    val onF = forDataType(from)
-    val onT = forDataType(to)
+    val onF = forDataTypeOrThrow(from)
+    val onT = forDataTypeOrThrow(to)
 
     if (onT.isInstanceOf[OnnxIntegral[_]]) { (a: from.Elem) =>
       onT.fromLong(onF.toLong(a))

--- a/core/src/main/scala/com/stripe/agate/tensor/OnnxShow.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/OnnxShow.scala
@@ -1,0 +1,50 @@
+package com.stripe.agate.tensor
+
+import cats.Show
+import com.google.protobuf.ByteString
+import com.stripe.dagon.HMap
+
+object OnnxShow {
+  val showUint8: Show[Byte] = Show.show(n => (n & 0xff).toString)
+  val showUint16: Show[Short] = Show.show(n => (n & 0xffff).toString)
+  val showInt8: Show[Byte] = Show.fromToString
+  val showInt16: Show[Short] = Show.fromToString
+  val showInt32: Show[Int] = Show.fromToString
+  val showInt64: Show[Long] = Show.fromToString
+  val showBFloat16: Show[Short] = Show.show(n => new BFloat16(n).toString)
+  val showFloat16: Show[Short] = Show.show(n => new Float16(n).toString)
+  val showFloat32: Show[Float] = Show.fromToString
+  val showFloat64: Show[Double] = Show.fromToString
+  val showString: Show[ByteString] = Show.show { s =>
+    // Renders a Python-style bytes string.
+    val bldr = new StringBuilder()
+    val it = s.iterator()
+    while (it.hasNext) {
+      val c = it.nextByte().toInt
+      if (c >= 32 && c <= 126) {
+        bldr.append(c.toChar)
+      } else {
+        bldr.append(f"\\x$c%02x")
+      }
+    }
+    bldr.toString
+  }
+
+  def forDataType(dt: DataType): Show[dt.Elem] =
+    forDataTypeMap(dt)
+
+  private[this] val forDataTypeMap: HMap[DataType.Aux, Show] =
+    HMap
+      .empty[DataType.Aux, Show]
+      .updated(DataType.Uint8, showUint8)
+      .updated(DataType.Uint16, showUint16)
+      .updated(DataType.Int8, showInt8)
+      .updated(DataType.Int16, showInt16)
+      .updated(DataType.Int32, showInt32)
+      .updated(DataType.Int64, showInt64)
+      .updated(DataType.BFloat16, showBFloat16)
+      .updated(DataType.Float16, showFloat16)
+      .updated(DataType.Float32, showFloat32)
+      .updated(DataType.Float64, showFloat64)
+      .updated(DataType.String, showString)
+}

--- a/core/src/main/scala/com/stripe/agate/tensor/OnnxShow.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/OnnxShow.scala
@@ -17,16 +17,17 @@ object OnnxShow {
   val showFloat64: Show[Double] = Show.fromToString
   val showString: Show[ByteString] = Show.show { s =>
     // Renders a Python-style bytes string.
-    val bldr = new StringBuilder()
+    val bldr = new StringBuilder("'")
     val it = s.iterator()
     while (it.hasNext) {
       val c = it.nextByte().toInt
-      if (c >= 32 && c <= 126) {
+      if ((c >= 32 && c <= 126) && (c != '\''.toInt) && (c != '\\'.toInt)) {
         bldr.append(c.toChar)
       } else {
         bldr.append(f"\\x$c%02x")
       }
     }
+    bldr.append("'")
     bldr.toString
   }
 

--- a/core/src/main/scala/com/stripe/agate/tensor/Storage.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Storage.scala
@@ -45,16 +45,59 @@ object Storage {
       if (len == 0L) ()
       else {
         val Dim(off, stride) = dim
-        var i = 0
-        var j = (offset + off).requireInt
-        val strideI: Int = stride.requireInt
-        val limit: Int = len.requireInt
-        while (i < limit) {
-          tb.put(os, data(j))
-          i += 1
-          j += strideI
+        if (tb.isFixedLength) {
+          writeIntoStreamFixedLength(os, off.requireInt, stride.requireInt, len.requireInt, tb)
+        } else {
+          writeIntoStreamVarLength(os, off.requireInt, stride.requireInt, len.requireInt, tb)
         }
       }
+
+    private def writeIntoStreamFixedLength(
+        os: OutputStream,
+        off: Int,
+        stride: Int,
+        len: Int,
+        tb: ToBytes[A]
+    ): Unit = {
+      var i = 0
+      var j = offset + off
+      while (i < len) {
+        tb.put(os, data(j))
+        i += 1
+        j += stride
+      }
+    }
+
+    private def writeIntoStreamVarLength(
+        os: OutputStream,
+        off: Int,
+        stride: Int,
+        len: Int,
+        tb: ToBytes[A]
+    ): Unit = {
+      val otb = ToBytes.longToBytes
+      val initOffset = offset + off
+      // Write the data offsets first. The first data element is written
+      // immediately after all the offset values have been written.
+      var dataOffset: Long = len * 8
+      var i = 0
+      var j = initOffset
+      while (i < len) {
+        otb.put(os, dataOffset)
+        dataOffset += tb.size(data(j))
+        i += 1
+        j += stride
+      }
+      // Write the data after. The offsets can provide fast indexing into
+      // these data if need be (eg for ByteBuffer-based storage).
+      i = 0
+      j = initOffset
+      while (i < len) {
+        tb.put(os, data(j))
+        i += 1
+        j += stride
+      }
+    }
   }
 
   final case class FloatBufferStorage(buffer: FloatBuffer, offset: Int) extends Storage[Float] {
@@ -164,8 +207,29 @@ object Storage {
     }
 
     def writeIntoStream(os: OutputStream, dim: Dim, len: Long)(implicit tb: ToBytes[A]): Unit =
-      foldLen(dim, len, ()) { (storage, _, d, l) =>
-        storage.writeIntoStream(os, d, l)
+      if (tb.isFixedLength) {
+        // In this case, we can just write them all out sequentially.
+        foldLen(dim, len, ()) { (storage, _, d, l) =>
+          storage.writeIntoStream(os, d, l)(tb)
+        }
+      } else {
+        // Write out index first.
+        val otb = ToBytes.longToBytes
+        foldLen(dim, len, 0L) { (storage, chunkOffset, d, l) =>
+          var offset = chunkOffset
+          foreachElem(storage, d, l) { a =>
+            otb.put(os, offset)
+            offset += tb.size(a)
+            ()
+          }
+          offset
+        }
+        // Write out the data after the index.
+        foldLen(dim, len, ()) { (storage, _, d, l) =>
+          foreachElem(storage, d, l) { a =>
+            tb.put(os, a)
+          }
+        }
       }
 
     def writeInto(out: WritableStorage[A], offset: Long, dim: Dim, len: Long): Unit = {
@@ -175,6 +239,21 @@ object Storage {
         o + l
       }
       ()
+    }
+  }
+
+  // This is a convenience method to iterate over elements in some storage
+  // using its apply method. This should typically not be used for fixed-length
+  // primitive types, but for variable-length types it is less bad, since the
+  // values are already boxed and we only pay for the overhead of calling f.
+  private def foreachElem[A](storage: Storage[A], dim: Dim, len: Long)(f: A => Unit): Unit = {
+    val Dim(offset, stride) = dim
+    var j = offset
+    var i = 0L
+    while (i < len) {
+      f(storage(j))
+      i += 1L
+      j += stride
     }
   }
 
@@ -212,49 +291,57 @@ object Storage {
       maxChunkSizeInBytes: Int
   ): Resource[IO, Storage[dt.Elem]] = {
     val tb = ToBytes.forDataType(dt)
-    val step = tb.size
-    if (maxChunkSizeInBytes < step) {
-      Resource.liftF(
-        IO.raiseError(
-          new IllegalArgumentException(s"maxChunkSizeInBytes=${maxChunkSizeInBytes} < $step")
+    tb.strategy match {
+      case _: ToBytes.Strategy.VarLength[_] =>
+        Resource.liftF(
+          IO.raiseError(
+            new IllegalArgumentException(s"unsupported datatype: $dt")
+          )
         )
-      )
-    } else {
-      openRandomAccessFileChannel(path.toFile).map {
-        case (length, channel) =>
-          val size = count * step
-          if (length < size) {
-            throw TensorException.InsufficentBytesToLoad(length, dt, size)
-          }
-          val maxSingleBytes = (maxChunkSizeInBytes / step) * step
-          @annotation.tailrec
-          def loop(
-              off: Long,
-              count: Long,
-              acc: List[(Storage[dt.Elem], Long)]
-          ): List[(Storage[dt.Elem], Long)] =
-            if (count <= 0) acc.reverse
-            else {
-              val sizeBytes = count * step
-              // definitely an integer multiple of step
-              val thisSize = sizeBytes min maxSingleBytes
-              val offBytes = off * step
-              val mapped = channel.map(FileChannel.MapMode.READ_ONLY, offBytes, thisSize)
-              mapped.order(ByteOrder.LITTLE_ENDIAN)
-              val store = storageFromBuffer(dt, mapped, 0)
-              val thisCount = thisSize / step
-              val nextCount = count - thisCount
-              val nextOff = off + thisCount
-              loop(nextOff, nextCount, (store, off) :: acc)
-            }
+      case ToBytes.Strategy.FixedLength(step) =>
+        if (maxChunkSizeInBytes < step) {
+          Resource.liftF(
+            IO.raiseError(
+              new IllegalArgumentException(s"maxChunkSizeInBytes=${maxChunkSizeInBytes} < $step")
+            )
+          )
+        } else {
+          openRandomAccessFileChannel(path.toFile).map {
+            case (length, channel) =>
+              val size = count * step
+              if (length < size) {
+                throw TensorException.InsufficentBytesToLoad(length, dt, size)
+              }
+              val maxSingleBytes = (maxChunkSizeInBytes / step) * step
+              @annotation.tailrec
+              def loop(
+                  off: Long,
+                  count: Long,
+                  acc: List[(Storage[dt.Elem], Long)]
+              ): List[(Storage[dt.Elem], Long)] =
+                if (count <= 0) acc.reverse
+                else {
+                  val sizeBytes = count * step
+                  // definitely an integer multiple of step
+                  val thisSize = sizeBytes min maxSingleBytes
+                  val offBytes = off * step
+                  val mapped = channel.map(FileChannel.MapMode.READ_ONLY, offBytes, thisSize)
+                  mapped.order(ByteOrder.LITTLE_ENDIAN)
+                  val store = storageFromBuffer(dt, mapped, 0)
+                  val thisCount = thisSize / step
+                  val nextCount = count - thisCount
+                  val nextOff = off + thisCount
+                  loop(nextOff, nextCount, (store, off) :: acc)
+                }
 
-          val (stores, offs) = loop(0L, count, Nil).unzip
-          stores match {
-            case single :: Nil => single
-            case many =>
-              Chunked(many.toArray, maxSingleBytes / step, 0L)
+              val (stores, offs) = loop(0L, count, Nil).unzip
+              stores match {
+                case single :: Nil => single
+                case many =>
+                  Chunked(many.toArray, maxSingleBytes / step, 0L)
+              }
           }
-      }
+        }
     }
   }
 }

--- a/core/src/main/scala/com/stripe/agate/tensor/StorageAllocator.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/StorageAllocator.scala
@@ -1,5 +1,6 @@
 package com.stripe.agate.tensor
 
+import com.google.protobuf.ByteString
 import com.stripe.dagon.HMap
 import scala.reflect.ClassTag
 
@@ -34,6 +35,9 @@ object StorageAllocator {
   implicit val doubleAllocator: StorageAllocator[Double] =
     new StorageAllocator[Double] {}
 
+  implicit val stringAllocator: StorageAllocator[ByteString] =
+    new StorageAllocator[ByteString] {}
+
   def forDataType(dt: DataType): StorageAllocator[dt.Elem] =
     forDataTypeMap(dt)
 
@@ -50,4 +54,5 @@ object StorageAllocator {
       .updated(DataType.Float16, shortAllocator)
       .updated(DataType.Float32, floatAllocator)
       .updated(DataType.Float64, doubleAllocator)
+      .updated(DataType.String, stringAllocator)
 }

--- a/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
@@ -125,7 +125,7 @@ abstract class Tensor[D <: DataType] {
           Util.closeTo(num.toFloat(x0), num.toFloat(x1), error)
         }
       case _ =>
-       // For all non-numeric datatypes, perform a strict equality check
+        // For all non-numeric datatypes, perform a strict equality check
         this == that
     }
 

--- a/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
@@ -125,6 +125,7 @@ abstract class Tensor[D <: DataType] {
           Util.closeTo(num.toFloat(x0), num.toFloat(x1), error)
         }
       case _ =>
+       // For all non-numeric datatypes, perform a strict equality check
         this == that
     }
 

--- a/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
@@ -224,9 +224,12 @@ abstract class Tensor[D <: DataType] {
         //isa.substitute[Tensor](this)
         this.asInstanceOf[Tensor[dest.type]] //fixme
       case None =>
-        val f: dataType.Elem => dest.Elem =
-          OnnxNumber.cast(dataType, dest)
-        this.map(dest)(f)
+        OnnxNumber.cast(dataType, dest) match {
+          case Some(f) =>
+            this.map(dest)(f)
+          case None =>
+            throw new IllegalArgumentException(s"cannot cast from $dataType to $dest")
+        }
     }
 
   /**

--- a/core/src/main/scala/com/stripe/agate/tensor/TensorException.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/TensorException.scala
@@ -1,10 +1,16 @@
 package com.stripe.agate.tensor
 
-sealed abstract class TensorException(message: String) extends Exception(message)
+sealed abstract class TensorException(message: String, cause: Throwable = null)
+    extends Exception(message, cause)
 
 object TensorException {
-  case class InsufficentBytesToLoad(bytesLength: Long, dt: DataType, len: Long)
-      extends TensorException(
-        s"loading ${dt.typeName} values, expected $len but only saw $bytesLength bytes"
+  case class InsufficentBytesToLoad(
+      bytesLength: Long,
+      dt: DataType,
+      len: Long,
+      cause: Throwable = null
+  ) extends TensorException(
+        s"loading ${dt.typeName} values, expected at least $len but only saw $bytesLength bytes",
+        cause
       )
 }

--- a/core/src/main/scala/com/stripe/agate/tensor/ToBytes.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/ToBytes.scala
@@ -10,17 +10,22 @@ import com.stripe.dagon.HMap
  * A type class for serializing values of type `A` into bytes.
  */
 trait ToBytes[@specialized A] {
+
   /**
    * The strategy is used to determine whether values of type `A` are a "fixed
-   * length" type or "variable length." In the case of fixed length types, the
-   * same amount of bytes will always be used to serialize a value.  For
-   * example, all `Int` values require 4 bytes. However, some types are
-   * variable length, like `ByteString`, and may require any number of bytes.
-   * In this case, we need to be able to quickly determine the size of a
-   * serialized value at runtime.
+   * length" encoding or "variable length" encoding. In the case of fixed
+   * length encodings, the same amount of bytes will always be used to
+   * serialize a value. For example, all `Int` values require 4 bytes. To
+   * serialize a tensor, we can just encode all the values in row-major order.
+   * For types with a variable length encoding, like `ByteString`, each value
+   * may require a different number of bytes. In this case, we need to be able
+   * to quickly determine the size of a serialized value at runtime. This size
+   * can be used when serializing a tensor to compute an index of offsets,
+   * which can be serialized along with the data. The index allows for random
+   * access into the serialized data.
    *
    * Note: Ideally, we'd just have 2 sub-classes of `ToBytes` to describe the
-   * different strategies, but this doesn't play well with serialization and
+   * different strategies, but this doesn't play well with specialization and
    * pattern matching.
    */
   def strategy: ToBytes.Strategy[A]

--- a/core/src/main/scala/com/stripe/agate/tensor/ToBytes.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/ToBytes.scala
@@ -10,7 +10,6 @@ import com.stripe.dagon.HMap
  * A type class for serializing values of type `A` into bytes.
  */
 trait ToBytes[@specialized A] {
-
   /**
    * The strategy is used to determine whether values of type `A` are a "fixed
    * length" encoding or "variable length" encoding. In the case of fixed

--- a/core/src/main/scala/com/stripe/agate/tensor/ToBytes.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/ToBytes.scala
@@ -3,27 +3,71 @@ package com.stripe.agate.tensor
 import java.io.OutputStream
 import java.lang.Float.{floatToRawIntBits, intBitsToFloat}
 import java.lang.Double.{doubleToRawLongBits, longBitsToDouble}
+import com.google.protobuf.ByteString
 import com.stripe.dagon.HMap
 
+/**
+ * A type class for serializing values of type `A` into bytes.
+ */
 trait ToBytes[@specialized A] {
-  def size: Int
-  def read(bytes: Array[Byte], i: Int): A
+  /**
+   * The strategy is used to determine whether values of type `A` are a "fixed
+   * length" type or "variable length." In the case of fixed length types, the
+   * same amount of bytes will always be used to serialize a value.  For
+   * example, all `Int` values require 4 bytes. However, some types are
+   * variable length, like `ByteString`, and may require any number of bytes.
+   * In this case, we need to be able to quickly determine the size of a
+   * serialized value at runtime.
+   *
+   * Note: Ideally, we'd just have 2 sub-classes of `ToBytes` to describe the
+   * different strategies, but this doesn't play well with serialization and
+   * pattern matching.
+   */
+  def strategy: ToBytes.Strategy[A]
+
+  def read(bytes: Array[Byte], offset: Int): A
   def put(os: OutputStream, n: A): Unit
+
+  /**
+   * Returns the number of bytes required to serialize `a`.
+   *
+   * Note: pattern matching on strategy in a specialized context leads to
+   * compile time type errors in the specialized implementations. This method
+   * should be used the size is required, since this kind of indirection to get
+   * things working correctly.
+   */
+  def size(a: A): Int = strategy.size(a)
+
+  def isFixedLength: Boolean = strategy match {
+    case ToBytes.Strategy.FixedLength(_) => true
+    case _                               => false
+  }
 }
 
 object ToBytes {
   def apply[A](implicit ev: ToBytes[A]): ToBytes[A] = ev
 
+  sealed trait Strategy[A] {
+    def size(value: A): Int
+  }
+
+  object Strategy {
+    case class FixedLength[A](size: Int) extends Strategy[A] {
+      def size(value: A): Int = size
+    }
+    trait VarLength[A] extends Strategy[A]
+  }
+
   implicit val byteToBytes: ToBytes[Byte] =
     new ToBytes[Byte] {
-      def size: Int = 1
+      def strategy: Strategy[Byte] = Strategy.FixedLength(1)
       def read(bytes: Array[Byte], i: Int): Byte = bytes(i)
       def put(os: OutputStream, n: Byte): Unit = os.write(n & 0xff)
     }
 
   implicit val shortToBytes: ToBytes[Short] =
     new ToBytes[Short] {
-      def size: Int = 2
+      def strategy: Strategy[Short] = Strategy.FixedLength(2)
       def read(bytes: Array[Byte], i: Int): Short = {
         val b0 = (bytes(i) & 0xff)
         val b1 = (bytes(i + 1) & 0xff) << 8
@@ -37,7 +81,7 @@ object ToBytes {
 
   implicit val intToBytes: ToBytes[Int] =
     new ToBytes[Int] {
-      def size: Int = 4
+      def strategy: Strategy[Int] = Strategy.FixedLength(4)
       def read(bytes: Array[Byte], i: Int): Int = {
         val b0 = (bytes(i) & 0xff)
         val b1 = (bytes(i + 1) & 0xff) << 8
@@ -55,7 +99,7 @@ object ToBytes {
 
   implicit val longToBytes: ToBytes[Long] =
     new ToBytes[Long] {
-      def size: Int = 8
+      def strategy: Strategy[Long] = Strategy.FixedLength(8)
       def read(bytes: Array[Byte], i: Int): Long = {
         val b0 = (bytes(i + 0) & 0XFFL) << 0L
         val b1 = (bytes(i + 1) & 0XFFL) << 8L
@@ -82,7 +126,7 @@ object ToBytes {
   implicit val floatToBytes: ToBytes[Float] =
     new ToBytes[Float] {
       val tb = ToBytes.intToBytes
-      def size: Int = 4
+      def strategy: Strategy[Float] = Strategy.FixedLength(4)
       def read(bytes: Array[Byte], i: Int): Float =
         intBitsToFloat(tb.read(bytes, i))
       def put(os: OutputStream, n: Float): Unit =
@@ -92,11 +136,52 @@ object ToBytes {
   implicit val doubleToBytes: ToBytes[Double] =
     new ToBytes[Double] {
       val tb = ToBytes.longToBytes
-      def size: Int = 8
+      def strategy: Strategy[Double] = Strategy.FixedLength(8)
       def read(bytes: Array[Byte], i: Int): Double =
         longBitsToDouble(tb.read(bytes, i))
       def put(os: OutputStream, n: Double): Unit =
         tb.put(os, doubleToRawLongBits(n))
+    }
+
+  // This encodes a ByteString by encoding its length as a varint first,
+  // followed by the data themselves.
+  implicit val byteStringToBytes: ToBytes[ByteString] =
+    new ToBytes[ByteString] {
+      val strategy: Strategy.VarLength[ByteString] =
+        new Strategy.VarLength[ByteString] {
+          def size(a: ByteString): Int = {
+            val len = a.size
+            // In the case of 0, we still use a single byte to store the 0.
+            val width = math.max(32 - java.lang.Integer.numberOfLeadingZeros(len), 1)
+            val varIntSize = (width + 7 - 1) / 7 // math.ceil(width / 7).toInt
+            varIntSize + len
+          }
+        }
+
+      def read(bytes: Array[Byte], offset: Int): ByteString = {
+        var len = 0
+        var s = 0
+        var n = bytes(offset)
+        var i = 1
+        while (n < 0) {
+          len = len | ((n & 0x7F) << s)
+          s += 7
+          n = bytes(offset + i)
+          i += 1
+        }
+        len = len | (n << s)
+        ByteString.copyFrom(bytes, offset + i, len)
+      }
+
+      def put(os: OutputStream, a: ByteString): Unit = {
+        var n = a.size
+        while ((n & ~0x7F) != 0) {
+          os.write((n & 0x7F) | 0x80)
+          n = n >>> 7
+        }
+        os.write(n)
+        a.writeTo(os)
+      }
     }
 
   val forDataTypeMap: HMap[DataType.Aux, ToBytes] =
@@ -112,6 +197,7 @@ object ToBytes {
       .updated(DataType.Float16, shortToBytes)
       .updated(DataType.Float32, floatToBytes)
       .updated(DataType.Float64, doubleToBytes)
+      .updated(DataType.String, byteStringToBytes)
 
   def forDataType(dt: DataType): ToBytes[dt.Elem] =
     forDataTypeMap(dt)

--- a/laws/src/main/scala/com/stripe/agate/laws/Check.scala
+++ b/laws/src/main/scala/com/stripe/agate/laws/Check.scala
@@ -28,10 +28,9 @@ object Check {
     )
 
   val genByteString: Gen[ByteString] =
-    Gen.choose(Byte.MinValue, Byte.MaxValue).map { b =>
-      ByteString.copyFrom(Array(b))
+    Gen.listOf(Gen.choose(Byte.MinValue, Byte.MaxValue)).map { bs =>
+      ByteString.copyFrom(bs.toArray)
     }
-  //Gen.listOf(Gen.choose(Byte.MinValue, Byte.MaxValue)).map { bs => ByteString.copyFrom(bs.toArray) }
 
   implicit val arbByteString: Arbitrary[ByteString] =
     Arbitrary(genByteString)

--- a/laws/src/main/scala/com/stripe/agate/laws/Check.scala
+++ b/laws/src/main/scala/com/stripe/agate/laws/Check.scala
@@ -2,6 +2,7 @@ package com.stripe.agate
 package laws
 
 import cats.implicits._
+import com.google.protobuf.ByteString
 import com.stripe.agate.tensor.{DataType, Shape, Tensor}
 import com.stripe.dagon.HMap
 import org.scalacheck.{Arbitrary, Cogen, Gen}
@@ -22,8 +23,18 @@ object Check {
       DataType.BFloat16,
       DataType.Float16,
       DataType.Float32,
-      DataType.Float64
+      DataType.Float64,
+      DataType.String
     )
+
+  val genByteString: Gen[ByteString] =
+    Gen.choose(Byte.MinValue, Byte.MaxValue).map { b =>
+      ByteString.copyFrom(Array(b))
+    }
+  //Gen.listOf(Gen.choose(Byte.MinValue, Byte.MaxValue)).map { bs => ByteString.copyFrom(bs.toArray) }
+
+  implicit val arbByteString: Arbitrary[ByteString] =
+    Arbitrary(genByteString)
 
   val elemForTypeMap: HMap[DataType.Aux, Gen] =
     HMap
@@ -38,6 +49,7 @@ object Check {
       .updated(DataType.Float16, Gen.choose(-10f, 10f).map(x => tensor.Float16.fromFloat(x).raw))
       .updated(DataType.Float32, Gen.choose(-10f, 10f))
       .updated(DataType.Float64, Gen.choose(-10.0, 10.0))
+      .updated(DataType.String, genByteString)
 
   def genElemForType(dt: DataType): Gen[dt.Elem] =
     elemForTypeMap[dt.Elem](dt)
@@ -218,6 +230,9 @@ object Check {
     val f: DataType => Gen[Tensor.Unknown] = (dt: DataType) => genTensor(dt)
     genDataType.flatMap(f)
   }
+
+  val genNumericTensor: Gen[Tensor.Unknown] =
+    genTensorU.filter(_.isNumeric)
 
   implicit val arbitraryTensorUnknown: Arbitrary[Tensor.Unknown] =
     Arbitrary(genTensorU)

--- a/tests/src/test/scala/com/stripe/agate/Onnx.scala
+++ b/tests/src/test/scala/com/stripe/agate/Onnx.scala
@@ -53,6 +53,8 @@ object Onnx {
         tp.copy(floatData = toSeq[Float](dt)(x => x))
       case dt: DataType.Float64.type =>
         tp.copy(doubleData = toSeq[Double](dt)(x => x))
+      case dt: DataType.String.type =>
+        tp.copy(stringData = toSeq[ByteString](dt)(x => x))
     }
   }
 

--- a/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/eval/OperationTest.scala
@@ -46,7 +46,8 @@ object OperationTest extends Properties("OperationTest") {
                   outReg.getAndUnify(reg, ex.dataType)
                 t match {
                   case Success(got) => p && (got =~= ex)
-                  case Failure(err) => p && (Prop(false) :| err.toString)
+                  case Failure(err) =>
+                    p && (Prop(false) :| err.toString)
                 }
             }
           case Failure(err) =>

--- a/tests/src/test/scala/com/stripe/agate/ops/SoftmaxTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/ops/SoftmaxTest.scala
@@ -92,7 +92,7 @@ y = softmax_2d(x)
   // if you softmax each element individually they all become 1.
   property("Softmax(t, t.rank) = const(1)") = forAll { (t: Tensor.F) =>
     val got = Softmax(t, axis = t.rank).get
-    val num = OnnxNumber.forDataType(t.dataType)
+    val num = OnnxNumber.forDataTypeOrThrow(t.dataType)
     val expected = Tensor.const(t.dataType)(num.one, t.axes)
     Claim(got == expected)
   }
@@ -100,7 +100,7 @@ y = softmax_2d(x)
   // adding a constant to each element doesn't change softmax.
   property("Softmax(t, axis) = Softmax(t + const(1), axis)") = forAll(genArg) {
     case Arg(t0, axis) =>
-      val num = OnnxNumber.forDataType(t0.dataType)
+      val num = OnnxNumber.forDataTypeOrThrow(t0.dataType)
       val t1 = t0.map(x => num.plus(x, num.one))
       val t2 = Softmax(t0, axis).get
       val t3 = Softmax(t1, axis).get

--- a/tests/src/test/scala/com/stripe/agate/tensor/ToBytesTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/tensor/ToBytesTest.scala
@@ -1,7 +1,8 @@
 package com.stripe.agate
 package tensor
 
-import org.scalacheck.Properties
+import com.google.protobuf.ByteString
+import org.scalacheck.{Arbitrary, Gen, Properties}
 import org.scalacheck.Prop.{forAllNoShrink => forAll}
 
 import java.io._
@@ -10,13 +11,13 @@ import org.typelevel.claimant.Claim
 object ToBytesTest extends Properties("ToBytesTest") {
   property("long values round-trip") = forAll { (n0: Long, n1: Long) =>
     val tb = ToBytes[Long]
-    val baos = new ByteArrayOutputStream(tb.size)
+    val baos = new ByteArrayOutputStream()
     tb.put(baos, n0)
     tb.put(baos, n1)
     baos.close()
     val bytes = baos.toByteArray
     val n2 = tb.read(bytes, 0)
-    val n3 = tb.read(bytes, tb.size)
+    val n3 = tb.read(bytes, tb.size(n0))
     val ok = n2 == n0 && n3 == n1
     if (!ok) {
       println(s"n2 (%d = %016x) = n0 (%d = %016x)".format(n2, n2, n0, n0))
@@ -24,5 +25,23 @@ object ToBytesTest extends Properties("ToBytesTest") {
       println("bytes = " + bytes.map(n => "%02x".format(n)).mkString)
     }
     Claim(n2 == n0) && Claim(n3 == n1)
+  }
+
+  implicit val arbByteString: Arbitrary[ByteString] =
+    Arbitrary(Gen.listOf(Arbitrary.arbitrary[Byte]).map { bs =>
+      ByteString.copyFrom(bs.toArray)
+    })
+
+  property("ByteString values round-trip") = forAll { (s0: ByteString, s1: ByteString) =>
+    val tb = ToBytes[ByteString]
+    val baos = new ByteArrayOutputStream()
+    tb.put(baos, s0)
+    tb.put(baos, s1)
+    baos.close()
+    val bytes = baos.toByteArray
+    val s2 = tb.read(bytes, 0)
+    val s3 = tb.read(bytes, tb.size(s0))
+    val expectedSize = tb.size(s0) + tb.size(s1)
+    Claim(bytes.length == expectedSize) && Claim(s2 == s0) && Claim(s3 == s1)
   }
 }


### PR DESCRIPTION
This PR adds support for the DT_STRING ONNX data type. This is used to represent arbitrary byte strings. The internal type used for elements is `ByteString` from Protobuf. This was complicated because we had assumed all types had fixed width serialization previously, whereas string types are variable. There are 2 changes to address this:
 - Addition of a "strategy" to the `ToBytes` type class to determine whether a type supports a fixed or variable width encoding.
 - Addition of a new serialization format for variable length types in `Tensor`. In this case, we store an index of offsets (`int64`) for the variable length data first, followed by the variable length data all encoded sequentially. For byte strings, we encode them by first encoding the length as a var int, followed by the data as-is.

This PR does not currently add support for memory-mapped string tensors. This seems like a good thing to support, since string-based tensors can easily grow quite large, but we can do it in a separate PR.