### PR TITLE
Fix bug in show instance for DataType.String.

### DIFF
--- a/core/src/main/scala/com/stripe/agate/tensor/OnnxShow.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/OnnxShow.scala
@@ -24,7 +24,7 @@ object OnnxShow {
       if ((c >= 32 && c <= 126) && (c != '\''.toInt) && (c != '\\'.toInt)) {
         bldr.append(c.toChar)
       } else {
-        bldr.append(f"\\x$c%02x")
+        bldr.append(f"\\x${c&0xFF}%02x")
       }
     }
     bldr.append("'")

--- a/core/src/main/scala/com/stripe/agate/tensor/OnnxShow.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/OnnxShow.scala
@@ -24,7 +24,7 @@ object OnnxShow {
       if ((c >= 32 && c <= 126) && (c != '\''.toInt) && (c != '\\'.toInt)) {
         bldr.append(c.toChar)
       } else {
-        bldr.append(f"\\x${c&0xFF}%02x")
+        bldr.append(f"\\x${c & 0xFF}%02x")
       }
     }
     bldr.append("'")

--- a/tests/src/test/scala/com/stripe/agate/tensor/OnnxShowTest.scala
+++ b/tests/src/test/scala/com/stripe/agate/tensor/OnnxShowTest.scala
@@ -1,0 +1,12 @@
+package com.stripe.agate.tensor
+
+import com.google.protobuf.ByteString
+import org.scalacheck.Properties
+import org.typelevel.claimant.Claim
+
+class OnnxShowTest extends Properties("OnnxShowTest") {
+  property("String instance encodes bytes succinctly") = Claim(
+    OnnxShow.showString
+      .show(ByteString.copyFrom(Array[Byte](0, Byte.MaxValue, -1, Byte.MinValue))) == "'\\x00\\x7f\\xff\\x80'"
+  )
+}


### PR DESCRIPTION
We weren't masking the `Int`, so were printing a bunch of leading `f`s for negative numbers. This just masks the into with `0xFF` when converting it to hex.