### PR TITLE
Switch to using a 0-offset data in index for varlen tensors

### DIFF
--- a/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
+++ b/core/src/main/scala/com/stripe/agate/tensor/Tensor.scala
@@ -808,10 +808,11 @@ object Tensor {
             }
           } else {
             val otb = ToBytes.longToBytes
+            val dataStart = len.requireInt
             try {
               while (i < len) {
                 val offset = otb.read(bytes, i).requireInt
-                val x = tb.read(bytes, offset)
+                val x = tb.read(bytes, dataStart + offset)
                 data.writeAt(j, x)
                 i += step
                 j += 1L
@@ -872,7 +873,7 @@ object Tensor {
       implicit tb: ToBytes[A]
   ): Unit = {
     val otb = ToBytes.longToBytes
-    var dataOffset: Long = len * 8
+    var dataOffset: Long = 0
     var i = 0
     while (i < len) {
       otb.put(os, dataOffset)


### PR DESCRIPTION
This matches TF's format, which makes interop easier.